### PR TITLE
Update struct names to use exported types

### DIFF
--- a/Bearer.go
+++ b/Bearer.go
@@ -72,7 +72,7 @@ type Bearer interface {
 	// Additional items which are only applicable when using the MM_BEARER_IP_METHOD_STATIC method are:
 	// address, prefix, dns1, dns2, dns3 and gateway
 	// This property may also include the following items when such information is available: mtu
-	GetIp4Config() (bearerIpConfig, error)
+	GetIp4Config() (BearerIpConfig, error)
 
 	// If the bearer was configured for IPv6 addressing, upon activation this property contains the addressing
 	// details for assignment to the data interface.
@@ -84,12 +84,12 @@ type Bearer interface {
 	// Additional items which are usually only applicable when using the MM_BEARER_IP_METHOD_STATIC method are:
 	// address, prefix, dns1, dns2, dns3 and gateway
 	// This property may also include the following items when such information is available: mtu
-	GetIp6Config() (bearerIpConfig, error)
+	GetIp6Config() (BearerIpConfig, error)
 
 	// If the modem supports it, this property will show statistics of the ongoing connection.
 	// When the connection is disconnected automatically or explicitly by the user, the values in this
 	// property will show the last values cached. The statistics are reset
-	GetStats() (bearerStats, error)
+	GetStats() (BearerStats, error)
 
 	// Maximum time to wait for a successful IP establishment, when PPP is used.
 	GetIpTimeout() (uint32, error)
@@ -125,8 +125,8 @@ type bearer struct {
 	sigChan chan *dbus.Signal
 }
 
-// bearerIpConfig represents all available ip configuration properties
-type bearerIpConfig struct {
+// BearerIpConfig represents all available ip configuration properties
+type BearerIpConfig struct {
 	Method   MMBearerIpMethod `json:"method"`    // Mandatory: A MMBearerIpMethod, given as an unsigned integer value (signature "u").
 	Address  string           `json:"address"`   // 	IP address, given as a string value (signature "s").
 	Prefix   uint32           `json:"prefix"`    // Numeric CIDR network prefix (ie, 24, 32, etc), given as an unsigned integer value (signature "u").
@@ -139,7 +139,7 @@ type bearerIpConfig struct {
 }
 
 // MarshalJSON returns a byte array
-func (bc bearerIpConfig) MarshalJSON() ([]byte, error) {
+func (bc BearerIpConfig) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"Method":     fmt.Sprint(bc.Method),
 		"Address":    bc.Address,
@@ -152,7 +152,7 @@ func (bc bearerIpConfig) MarshalJSON() ([]byte, error) {
 		"IpFamily: ": fmt.Sprint(bc.IpFamily)})
 }
 
-func (bc bearerIpConfig) String() string {
+func (bc BearerIpConfig) String() string {
 	return "Method: " + fmt.Sprint(bc.Method) +
 		", Address: " + bc.Address +
 		", Prefix: " + fmt.Sprint(bc.Prefix) +
@@ -201,22 +201,22 @@ func (bp BearerProperty) String() string {
 		", Number: " + bp.Number
 }
 
-// bearerStats represents all stats according to the bearer
-type bearerStats struct {
+// BearerStats represents all stats according to the bearer
+type BearerStats struct {
 	RxBytes  uint64 `json:"rx-bytes"` // Number of bytes received without error, given as an unsigned 64-bit integer value (signature "t").
 	TxBytes  uint64 `json:"tx-bytes"` // Number bytes transmitted without error, given as an unsigned 64-bit integer value (signature "t").
 	Duration uint32 `json:"duration"` // Duration of the connection, in seconds, given as an unsigned integer value (signature "u").
 }
 
 // MarshalJSON returns a byte array
-func (bs bearerStats) MarshalJSON() ([]byte, error) {
+func (bs BearerStats) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"RxBytes":  bs.RxBytes,
 		"TxBytes":  bs.TxBytes,
 		"Duration": bs.Duration,
 	})
 }
-func (bs bearerStats) String() string {
+func (bs BearerStats) String() string {
 	return "RxBytes: " + fmt.Sprint(bs.RxBytes) +
 		", TxBytes: " + fmt.Sprint(bs.TxBytes) +
 		", Duration: " + fmt.Sprint(bs.Duration)
@@ -245,7 +245,7 @@ func (be bearer) GetSuspended() (bool, error) {
 	return be.getBoolProperty(BearerPropertySuspended)
 }
 
-func (be bearer) GetIp4Config() (bi bearerIpConfig, err error) {
+func (be bearer) GetIp4Config() (bi BearerIpConfig, err error) {
 	tmpMap, err := be.getMapStringVariantProperty(BearerPropertyIp4Config)
 	if err != nil {
 		return bi, err
@@ -300,7 +300,7 @@ func (be bearer) GetIp4Config() (bi bearerIpConfig, err error) {
 	return
 }
 
-func (be bearer) GetIp6Config() (bi bearerIpConfig, err error) {
+func (be bearer) GetIp6Config() (bi BearerIpConfig, err error) {
 	tmpMap, err := be.getMapStringVariantProperty(BearerPropertyIp6Config)
 	if err != nil {
 		return bi, err
@@ -354,7 +354,7 @@ func (be bearer) GetIp6Config() (bi bearerIpConfig, err error) {
 	return
 }
 
-func (be bearer) GetStats() (br bearerStats, err error) {
+func (be bearer) GetStats() (br BearerStats, err error) {
 	tmpMap, err := be.getMapStringVariantProperty(BearerPropertyStats)
 	if err != nil {
 		return br, err

--- a/Call.go
+++ b/Call.go
@@ -99,7 +99,7 @@ type Call interface {
 	GetAudioPort() (string, error)
 
 	// If call audio is routed via the host, a description of the audio format supported by the audio port.
-	GetAudioFormat() (audioFormat, error)
+	GetAudioFormat() (AudioFormat, error)
 
 	/* SIGNALS */
 
@@ -146,21 +146,21 @@ type call struct {
 	sigChan chan *dbus.Signal
 }
 
-type audioFormat struct {
+type AudioFormat struct {
 	Encoding   string `json:"encoding"`   // The audio encoding format. For example, "pcm" for PCM audio.
 	Resolution string `json:"resolution"` // The sampling precision and its encoding format. For example, "s16le" for signed 16-bit little-endian samples
 	Rate       uint32 `json:"rate"`       // The sampling rate as an unsigned integer. For example, 8000 for 8000hz.
 }
 
 // MarshalJSON returns a byte array
-func (af audioFormat) MarshalJSON() ([]byte, error) {
+func (af AudioFormat) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"Encoding":   af.Encoding,
 		"Resolution": af.Resolution,
 		"Rate":       af.Rate,
 	})
 }
-func (af audioFormat) String() string {
+func (af AudioFormat) String() string {
 	return returnString(af)
 
 }
@@ -233,7 +233,7 @@ func (ca call) GetAudioPort() (string, error) {
 	return ca.getStringProperty(CallPropertyAudioPort)
 }
 
-func (ca call) GetAudioFormat() (af audioFormat, err error) {
+func (ca call) GetAudioFormat() (af AudioFormat, err error) {
 	tmpMap, err := ca.getMapStringVariantProperty(CallPropertyAudioFormat)
 	if err != nil {
 		return af, err

--- a/Modem.go
+++ b/Modem.go
@@ -225,7 +225,7 @@ type Modem interface {
 
 	// The list of ports in the modem, given as an array of string and unsigned integer pairs.
 	// The string is the port name or path, and the integer is the port type given as a MMModemPortType value.
-	GetPorts() ([]port, error)
+	GetPorts() ([]Port, error)
 
 	// The identity of the device. This will be the IMEI number for GSM devices and the hex-format ESN/MEID for CDMA devices.
 	GetEquipmentIdentifier() (string, error)
@@ -318,13 +318,13 @@ type modem struct {
 }
 
 // Represents the modem port (name and type)
-type port struct {
+type Port struct {
 	PortName string          // Port Name or Path
 	PortType MMModemPortType // Modem Port Type
 }
 
 // MarshalJSON returns a byte array
-func (po port) MarshalJSON() ([]byte, error) {
+func (po Port) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"PortName":  po.PortName,
 		"PortType ": po.PortType,
@@ -561,7 +561,7 @@ func (m modem) GetPrimaryPort() (string, error) {
 	return m.getStringProperty(ModemPropertyPrimaryPort)
 }
 
-func (m modem) GetPorts() (ports []port, err error) {
+func (m modem) GetPorts() (ports []Port, err error) {
 	res, err := m.getSliceSlicePairProperty(ModemPropertyPorts)
 	if err != nil {
 		return nil, err
@@ -576,7 +576,7 @@ func (m modem) GetPorts() (ports []port, err error) {
 
 			return nil, errors.New("wrong type != uin32")
 		}
-		ports = append(ports, port{PortName: newA, PortType: MMModemPortType(newB)})
+		ports = append(ports, Port{PortName: newA, PortType: MMModemPortType(newB)})
 	}
 	return
 }

--- a/ModemLocation.go
+++ b/ModemLocation.go
@@ -66,7 +66,7 @@ type ModemLocation interface {
 
 	// Return current location information, if any. If the modelo supports multiple location types it may return more than one. See the "Location" property for more information on the dictionary returned at location.
 	// This method may require the client to authenticate itself.
-	GetCurrentLocation() (currentLocation, error)
+	GetCurrentLocation() (CurrentLocation, error)
 
 	// Configure the SUPL server for A-GPS.
 	// IN s supl: SUPL server configuration, given either as IP:PORT or as FQDN:PORT.
@@ -102,7 +102,7 @@ type ModemLocation interface {
 	// supports multiple location types it may return more than one here.
 	// Note that if the device was told not to emit updated location information when location information
 	// gathering was initially enabled, this property may not return any location information for security reasons.
-	GetLocation() (currentLocation, error)
+	GetLocation() (CurrentLocation, error)
 
 	// SUPL server configuration for A-GPS, given either as IP:PORT or FQDN:PORT.
 	GetSuplServer() (string, error)
@@ -124,16 +124,16 @@ type modemLocation struct {
 	dbusBase
 }
 
-// currentLocation represents all available/activated locations of the modem
-type currentLocation struct {
-	ThreeGppLacCi threeGppLacCiLocation `json:"3gpp-lac-ci"` // Devices supporting this capability return a string in the format "MCC,MNC,LAC,CI,TAC" (without the quotes of course)
-	GpsRaw        gpsRawLocation        `json:"gps-raw"`     // Devices supporting this capability return a D-Bus dictionary (signature "a{sv}") mapping well-known keys to values with defined formats.
-	GpsNmea       gpsNmeaLocation       `json:"gps-nmea"`    // Devices supporting this capability return a string containing one or more NMEA sentences (D-Bus signature 's'). The manager will cache the most recent NMEA sentence of each type for a period of time not less than 30 seconds. When reporting multiple NMEA sentences, sentences shall be separated by an ASCII Carriage Return and Line Feed (<CR><LF>) sequence.
-	CdmaBs        cdmaBsLocation        `json:"cdma-bs"`     // Devices supporting this capability return a D-Bus dictionary (signature "a{sv}") mapping well-known keys to values with defined formats.
+// CurrentLocation represents all available/activated locations of the modem
+type CurrentLocation struct {
+	ThreeGppLacCi ThreeGppLacCiLocation `json:"3gpp-lac-ci"` // Devices supporting this capability return a string in the format "MCC,MNC,LAC,CI,TAC" (without the quotes of course)
+	GpsRaw        GpsRawLocation        `json:"gps-raw"`     // Devices supporting this capability return a D-Bus dictionary (signature "a{sv}") mapping well-known keys to values with defined formats.
+	GpsNmea       GpsNmeaLocation       `json:"gps-nmea"`    // Devices supporting this capability return a string containing one or more NMEA sentences (D-Bus signature 's'). The manager will cache the most recent NMEA sentence of each type for a period of time not less than 30 seconds. When reporting multiple NMEA sentences, sentences shall be separated by an ASCII Carriage Return and Line Feed (<CR><LF>) sequence.
+	CdmaBs        CdmaBsLocation        `json:"cdma-bs"`     // Devices supporting this capability return a D-Bus dictionary (signature "a{sv}") mapping well-known keys to values with defined formats.
 }
 
 // MarshalJSON returns a byte array
-func (cl currentLocation) MarshalJSON() ([]byte, error) {
+func (cl CurrentLocation) MarshalJSON() ([]byte, error) {
 	threeGppLacCiJson, err := cl.ThreeGppLacCi.MarshalJSON()
 	if err != nil {
 		return nil, err
@@ -158,12 +158,12 @@ func (cl currentLocation) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (cl currentLocation) String() string {
+func (cl CurrentLocation) String() string {
 	return returnString(cl)
 
 }
 
-type threeGppLacCiLocation struct {
+type ThreeGppLacCiLocation struct {
 	Mcc string `json:"MCC"` // This is the three-digit ITU E.212 Mobile Country Code of the network provider to which the mobile is currently registered. e.g. "310".
 	Mnc string `json:"MNC"` // This is the two- or three-digit GSM Mobile Network Code of the network provider to which the mobile is currently registered. e.g. "26" or "260".
 	Lac string `json:"LAC"` // This is the two-byte Location Area Code of the GSM/UMTS base station with which the mobile is registered, in upper-case hexadecimal format without leading zeros, as specified in 3GPP TS 27.007. E.g. "84CD".
@@ -172,7 +172,7 @@ type threeGppLacCiLocation struct {
 }
 
 // MarshalJSON returns a byte array
-func (tgp threeGppLacCiLocation) MarshalJSON() ([]byte, error) {
+func (tgp ThreeGppLacCiLocation) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"Mcc": tgp.Mcc,
 		"Mnc": tgp.Mnc,
@@ -182,24 +182,24 @@ func (tgp threeGppLacCiLocation) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (tgp threeGppLacCiLocation) String() string {
+func (tgp ThreeGppLacCiLocation) String() string {
 	return returnString(tgp)
 }
 
-type gpsRawLocation struct {
+type GpsRawLocation struct {
 	UtcTime   time.Time `json:"utc-time"`  // (Required) UTC time in ISO 8601 format, given as a string value (signature "s"). e.g. 203015.
 	Latitude  float64   `json:"latitude"`  // (Required) Latitude in Decimal Degrees (positive numbers mean N quadrasphere, negative mean S quadrasphere), given as a double value (signature "d"). e.g. 38.889722, meaning 38d 53' 22" N.
 	Longitude float64   `json:"longitude"` // (Required) Longitude in Decimal Degrees (positive numbers mean E quadrasphere, negative mean W quadrasphere), given as a double value (signature "d"). e.g. -77.008889, meaning 77d 0' 32" W.
 	Altitude  float64   `json:"altitude"`  // (Optional) Altitude above sea level in meters, given as a double value (signature "d"). e.g. 33.5.
 }
 
-func (rgps gpsRawLocation) String() string {
+func (rgps GpsRawLocation) String() string {
 	return returnString(rgps)
 
 }
 
 // MarshalJSON returns a byte array
-func (rgps gpsRawLocation) MarshalJSON() ([]byte, error) {
+func (rgps GpsRawLocation) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"UtcTime":   rgps.UtcTime,
 		"Latitude":  rgps.Latitude,
@@ -208,35 +208,35 @@ func (rgps gpsRawLocation) MarshalJSON() ([]byte, error) {
 	})
 }
 
-type gpsNmeaLocation struct {
+type GpsNmeaLocation struct {
 	NmeaSentences []string `json:"nmea-sentances"` // Devices supporting this capability return a string containing one or more NMEA sentences (D-Bus signature 's'). The manager will cache the most recent NMEA sentence of each type for a period of time not less than 30 seconds. When reporting multiple NMEA sentences, sentences shall be separated by an ASCII Carriage Return and Line Feed (<CR><LF>) sequence. The manager may discard any cached sentences older than 30 seconds.  This allows clients to read the latest positioning data as soon as possible after they start, even if the device is not providing frequent location data updates.
 }
 
 // MarshalJSON returns a byte array
-func (ngps gpsNmeaLocation) MarshalJSON() ([]byte, error) {
+func (ngps GpsNmeaLocation) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"NmeaSentences": ngps.NmeaSentences,
 	})
 }
 
-func (ngps gpsNmeaLocation) String() string {
+func (ngps GpsNmeaLocation) String() string {
 	return returnString(ngps)
 }
 
-type cdmaBsLocation struct {
+type CdmaBsLocation struct {
 	Latitude  float64 `json:"latitude"`  // (Required) Latitude in Decimal Degrees (positive numbers mean N quadrasphere, negative mean S quadrasphere), given as a double value (signature "d"). e.g. 38.889722, meaning 38d 53' 22" N.
 	Longitude float64 `json:"longitude"` // (Required) Longitude in Decimal Degrees (positive numbers mean E quadrasphere, negative mean W quadrasphere), given as a double value (signature "d"). e.g. -77.008889, meaning 77d 0' 32" W.
 }
 
 // MarshalJSON returns a byte array
-func (cdma cdmaBsLocation) MarshalJSON() ([]byte, error) {
+func (cdma CdmaBsLocation) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"Latitude":  cdma.Latitude,
 		"Longitude": cdma.Longitude,
 	})
 }
 
-func (cdma cdmaBsLocation) String() string {
+func (cdma CdmaBsLocation) String() string {
 	return returnString(cdma)
 
 }
@@ -252,7 +252,7 @@ func (lo modemLocation) Setup(sources []MMModemLocationSource, enableSignal bool
 	return lo.call(ModemLocationSetup, &bitmask, &enableSignal)
 }
 
-func (lo modemLocation) GetCurrentLocation() (loc currentLocation, err error) {
+func (lo modemLocation) GetCurrentLocation() (loc CurrentLocation, err error) {
 	var res map[uint32]dbus.Variant
 	err = lo.callWithReturn(&res, ModemLocationGetLocation)
 	if err != nil {
@@ -306,14 +306,14 @@ func (lo modemLocation) GetSignalsLocation() (bool, error) {
 	return lo.getBoolProperty(ModemLocationPropertySignalsLocation)
 }
 
-func (lo modemLocation) GetLocation() (locs currentLocation, err error) {
+func (lo modemLocation) GetLocation() (locs CurrentLocation, err error) {
 	res, err := lo.getMapUint32VariantProperty(ModemLocationPropertyLocation)
 	if err != nil {
 		return
 	}
 	return lo.createLocation(res)
 }
-func (lo modemLocation) createLocation(res map[uint32]dbus.Variant) (locs currentLocation, err error) {
+func (lo modemLocation) createLocation(res map[uint32]dbus.Variant) (locs CurrentLocation, err error) {
 	var sourceTypeM MMModemLocationSource
 	for key, element := range res {
 		sType := sourceTypeM.BitmaskToSlice(key)
@@ -326,7 +326,7 @@ func (lo modemLocation) createLocation(res map[uint32]dbus.Variant) (locs curren
 				if ok {
 					res := strings.Split(tmpString, ",")
 					if len(res) == 5 {
-						var three threeGppLacCiLocation
+						var three ThreeGppLacCiLocation
 						three.Mcc = res[0]
 						three.Mnc = res[1]
 						three.Lac = res[2]
@@ -341,7 +341,7 @@ func (lo modemLocation) createLocation(res map[uint32]dbus.Variant) (locs curren
 			case MmModemLocationSourceGpsRaw:
 				tmpMap, ok := element.Value().(map[string]interface{})
 
-				var gpsRaw gpsRawLocation
+				var gpsRaw GpsRawLocation
 				if ok {
 					for k, v := range tmpMap {
 						switch k {
@@ -382,7 +382,7 @@ func (lo modemLocation) createLocation(res map[uint32]dbus.Variant) (locs curren
 			case MmModemLocationSourceGpsNmea:
 				tmpString, ok := element.Value().(string)
 				if ok {
-					var nmea gpsNmeaLocation
+					var nmea GpsNmeaLocation
 					splitString := strings.Split(tmpString, "\n")
 					var tmpRes []string
 					for _, nmea := range splitString {
@@ -398,7 +398,7 @@ func (lo modemLocation) createLocation(res map[uint32]dbus.Variant) (locs curren
 				// todo: untested
 				tmpMap, ok := element.Value().(map[string]float64)
 				if ok {
-					var cdma cdmaBsLocation
+					var cdma CdmaBsLocation
 					for k, v := range tmpMap {
 						switch k {
 						case "latitude":

--- a/ModemOma.go
+++ b/ModemOma.go
@@ -61,7 +61,7 @@ type ModemOma interface {
 	// List of network-initiated sessions which are waiting to be accepted or rejected, given as an array of unsigned integer pairs, where:
 	// 		The first integer is a MMOmaSessionType.
 	// 		The second integer is the unique session ID.
-	GetPendingNetworkInitiatedSessions() ([]modemOmaInitiatedSession, error)
+	GetPendingNetworkInitiatedSessions() ([]ModemOmaInitiatedSession, error)
 
 	// Type of the current on-going device management session, given as a MMOmaSessionType.
 	GetSessionType() (MMOmaSessionType, error)
@@ -92,20 +92,20 @@ type modemOma struct {
 	sigChan chan *dbus.Signal
 }
 
-type modemOmaInitiatedSession struct {
+type ModemOmaInitiatedSession struct {
 	SessionType MMOmaSessionType `json:"session-type"` // network-initiated session type
 	SessionId   uint32           `json:"session-id"`   // network-initiated session id
 }
 
 // MarshalJSON returns a byte array
-func (mois modemOmaInitiatedSession) MarshalJSON() ([]byte, error) {
+func (mois ModemOmaInitiatedSession) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"SessionType": fmt.Sprint(mois.SessionType),
 		"SessionId":   mois.SessionId,
 	})
 }
 
-func (mois modemOmaInitiatedSession) String() string {
+func (mois ModemOmaInitiatedSession) String() string {
 	return "SessionType: " + fmt.Sprint(mois.SessionType) +
 		", SessionId: " + fmt.Sprint(mois.SessionId)
 }
@@ -143,13 +143,13 @@ func (om modemOma) GetFeatures() ([]MMOmaFeature, error) {
 
 }
 
-func (om modemOma) GetPendingNetworkInitiatedSessions() (result []modemOmaInitiatedSession, err error) {
+func (om modemOma) GetPendingNetworkInitiatedSessions() (result []ModemOmaInitiatedSession, err error) {
 	res, err := om.getSliceSlicePairProperty(ModemOmaPropertyPendingNetworkInitiatedSessions)
 	if err != nil {
 		return nil, err
 	}
 	for _, e := range res {
-		var tmp modemOmaInitiatedSession
+		var tmp ModemOmaInitiatedSession
 		sType, ok := e.GetLeft().(uint32)
 		if !ok {
 			return nil, errors.New("wrong type")

--- a/ModemSignal.go
+++ b/ModemSignal.go
@@ -42,22 +42,22 @@ type ModemSignal interface {
 	GetRate() (rate uint32, err error)
 
 	// Returns all available cmda,evdo, gsm,umts or lte signal properties objects where rssi is set
-	GetCurrentSignals() (sp []signalProperty, err error)
+	GetCurrentSignals() (sp []SignalProperty, err error)
 
 	// The CDMA1x access technology.
-	GetCdma() (signalProperty, error)
+	GetCdma() (SignalProperty, error)
 
 	// The CDMA EV-DO access technology.
-	GetEvdo() (signalProperty, error)
+	GetEvdo() (SignalProperty, error)
 
 	// The GSM/GPRS access technology.
-	GetGsm() (signalProperty, error)
+	GetGsm() (SignalProperty, error)
 
 	// The UMTS (WCDMA)  access technology.
-	GetUmts() (signalProperty, error)
+	GetUmts() (SignalProperty, error)
 
 	// The LTE access technology.
-	GetLte() (signalProperty, error)
+	GetLte() (SignalProperty, error)
 }
 
 // NewModemSignal returns new ModemSignal Interface
@@ -70,8 +70,8 @@ type modemSignal struct {
 	dbusBase
 }
 
-// signalProperty represents all available signal properties
-type signalProperty struct {
+// SignalProperty represents all available signal properties
+type SignalProperty struct {
 	Type MMSignalPropertyType `json:"property-type"` // define the Signal Property Type
 	Rssi float64              `json:"rssi"`          // The CDMA1x / CDMA EV-DO / GSM / UMTS / LTE RSSI (Received Signal Strength Indication), in dBm, given as a floating point value (Applicable for all types).
 	Ecio float64              `json:"ecio"`          // The CDMA1x Ec/Io / CDMA EV-DO Ec/Io / UMTS Ec/Io level in dBm, given as a floating point value (Only applicable for type Cdma, Evdo, Umts).
@@ -84,7 +84,7 @@ type signalProperty struct {
 }
 
 // MarshalJSON returns a byte array
-func (sp signalProperty) MarshalJSON() ([]byte, error) {
+func (sp SignalProperty) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"Type": fmt.Sprint(sp.Type),
 		"Rssi": sp.Rssi,
@@ -98,7 +98,7 @@ func (sp signalProperty) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (sp signalProperty) String() string {
+func (sp SignalProperty) String() string {
 	return "Type: " + fmt.Sprint(sp.Type) +
 		", Rssi: " + fmt.Sprint(sp.Rssi) +
 		", Ecio: " + fmt.Sprint(sp.Ecio) +
@@ -109,7 +109,7 @@ func (sp signalProperty) String() string {
 		", Rsrp: " + fmt.Sprint(sp.Rsrp) +
 		", Snr: " + fmt.Sprint(sp.Snr)
 }
-func convertMapToSignalProperty(inputMap map[string]dbus.Variant, signalType MMSignalPropertyType) (sp signalProperty) {
+func convertMapToSignalProperty(inputMap map[string]dbus.Variant, signalType MMSignalPropertyType) (sp SignalProperty) {
 	sp.Type = signalType
 	for key, element := range inputMap {
 		switch key {
@@ -179,7 +179,7 @@ func (si modemSignal) GetRate() (rate uint32, err error) {
 	return si.getUint32Property(ModemSignalPropertyRate)
 }
 
-func (si modemSignal) GetCdma() (sp signalProperty, err error) {
+func (si modemSignal) GetCdma() (sp SignalProperty, err error) {
 	res, err := si.getMapStringVariantProperty(ModemSignalPropertyCdma)
 	if err != nil {
 		return
@@ -188,7 +188,7 @@ func (si modemSignal) GetCdma() (sp signalProperty, err error) {
 	return
 }
 
-func (si modemSignal) GetEvdo() (sp signalProperty, err error) {
+func (si modemSignal) GetEvdo() (sp SignalProperty, err error) {
 	res, err := si.getMapStringVariantProperty(ModemSignalPropertyEvdo)
 	if err != nil {
 		return
@@ -197,7 +197,7 @@ func (si modemSignal) GetEvdo() (sp signalProperty, err error) {
 	return
 }
 
-func (si modemSignal) GetGsm() (sp signalProperty, err error) {
+func (si modemSignal) GetGsm() (sp SignalProperty, err error) {
 	res, err := si.getMapStringVariantProperty(ModemSignalPropertyGsm)
 	if err != nil {
 		return
@@ -206,7 +206,7 @@ func (si modemSignal) GetGsm() (sp signalProperty, err error) {
 	return
 }
 
-func (si modemSignal) GetUmts() (sp signalProperty, err error) {
+func (si modemSignal) GetUmts() (sp SignalProperty, err error) {
 	res, err := si.getMapStringVariantProperty(ModemSignalPropertyUmts)
 	if err != nil {
 		return
@@ -215,7 +215,7 @@ func (si modemSignal) GetUmts() (sp signalProperty, err error) {
 	return
 }
 
-func (si modemSignal) GetLte() (sp signalProperty, err error) {
+func (si modemSignal) GetLte() (sp SignalProperty, err error) {
 	res, err := si.getMapStringVariantProperty(ModemSignalPropertyLte)
 	if err != nil {
 		return
@@ -224,7 +224,7 @@ func (si modemSignal) GetLte() (sp signalProperty, err error) {
 	sp = convertMapToSignalProperty(res, MMSignalPropertyTypeLte)
 	return
 }
-func (si modemSignal) isRssiSet(sp signalProperty) bool {
+func (si modemSignal) isRssiSet(sp SignalProperty) bool {
 	v := reflect.ValueOf(sp)
 	st := reflect.TypeOf(sp)
 	for i := 0; i < v.NumField(); i++ {
@@ -239,7 +239,7 @@ func (si modemSignal) isRssiSet(sp signalProperty) bool {
 	return false
 
 }
-func (si modemSignal) GetCurrentSignals() (sp []signalProperty, err error) {
+func (si modemSignal) GetCurrentSignals() (sp []SignalProperty, err error) {
 	mSignalCdma, err := si.GetCdma()
 	if err != nil {
 		return sp, err

--- a/ModemSimple.go
+++ b/ModemSimple.go
@@ -42,7 +42,7 @@ type ModemSimple interface {
 	Disconnect(bearer Bearer) error
 
 	// Get the general modem status.
-	GetStatus() (simpleStatus, error)
+	GetStatus() (SimpleStatus, error)
 }
 
 // SimpleProperties defines all available properties
@@ -79,8 +79,8 @@ func (sp SimpleProperties) String() string {
 	return returnString(sp)
 }
 
-// simpleStatus represents all properties of the current connection state
-type simpleStatus struct {
+// SimpleStatus represents all properties of the current connection state
+type SimpleStatus struct {
 	State                       MMModemState                 `json:"state"`                          // A MMModemState value specifying the overall state of the modem, given as an unsigned integer value (signature "u")
 	SignalQuality               uint32                       `json:"signal-quality"`                 // Signal quality value, given only when registered, as an unsigned integer value (signature "u").
 	CurrentBands                []MMModemBand                `json:"current-bands"`                  // List of MMModemBand values, given only when registered, as a list of unsigned integer values (signature "au").
@@ -94,12 +94,12 @@ type simpleStatus struct {
 	CdmaNid                     uint32                       `json:"cdma-nid"`                       // The Network Identifier of the serving network, if registered in a CDMA1x network and if known. Given as an unsigned integer value (signature "u").
 }
 
-func (ss simpleStatus) String() string {
+func (ss SimpleStatus) String() string {
 	return returnString(ss)
 }
 
 // MarshalJSON returns a byte array
-func (ss simpleStatus) MarshalJSON() ([]byte, error) {
+func (ss SimpleStatus) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"State":                       fmt.Sprint(ss.State),
 		"SignalQuality":               ss.SignalQuality,
@@ -152,7 +152,7 @@ func (ms modemSimple) Disconnect(bearer Bearer) error {
 	return ms.call(ModemSimpleDisconnect, bearer.GetObjectPath())
 }
 
-func (ms modemSimple) GetStatus() (status simpleStatus, err error) {
+func (ms modemSimple) GetStatus() (status SimpleStatus, err error) {
 	type dynMap interface{}
 	var myMap map[string]dynMap
 	myMap = make(map[string]dynMap)

--- a/ModemTime.go
+++ b/ModemTime.go
@@ -41,7 +41,7 @@ type ModemTime interface {
 
 	/* PROPERTIES */
 	// The timezone data provided by the network.
-	GetNetworkTimezone() (modemTimeZone, error)
+	GetNetworkTimezone() (ModemTimeZone, error)
 
 	/* SIGNALS */
 	// Sent when the network time is updated.
@@ -65,14 +65,14 @@ type modemTime struct {
 }
 
 // Represents the TimeZone of the Modem
-type modemTimeZone struct {
+type ModemTimeZone struct {
 	Offset      int32 `json:"offset"`       // Offset of the timezone from UTC, in minutes (including DST, if applicable), given as a signed integer value (signature "i").
 	DstOffset   int32 `json:"dst-offset"`   // Amount of offset that is due to DST (daylight saving time), given as a signed integer value (signature "i").
 	LeapSeconds int32 `json:"leap-seconds"` // Number of leap seconds included in the network time, given as a signed integer value (signature "i").
 }
 
 // MarshalJSON returns a byte array
-func (mtz modemTimeZone) MarshalJSON() ([]byte, error) {
+func (mtz ModemTimeZone) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"Offset":       mtz.Offset,
 		"DstOffset ":   mtz.DstOffset,
@@ -80,7 +80,7 @@ func (mtz modemTimeZone) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (mtz modemTimeZone) String() string {
+func (mtz ModemTimeZone) String() string {
 	return "Offset: " + fmt.Sprint(mtz.Offset) +
 		", DstOffset: " + fmt.Sprint(mtz.DstOffset) +
 		", LeapSeconds: " + fmt.Sprint(mtz.LeapSeconds)
@@ -103,7 +103,7 @@ func (ti modemTime) GetNetworkTime() (time.Time, error) {
 	return t, err
 }
 
-func (ti modemTime) GetNetworkTimezone() (mTz modemTimeZone, err error) {
+func (ti modemTime) GetNetworkTimezone() (mTz ModemTimeZone, err error) {
 	tmpMap, err := ti.getMapStringVariantProperty(ModemTimePropertyNetworkTimezone)
 	if err != nil {
 		return mTz, err


### PR DESCRIPTION
The struct names in various files were updated to start with a capital letter which makes them exported and usable in other packages. This change allows these types to be used directly (declaration, parameters, return type).

Types that need initialization (and have a pseudo-constructor) and are exported through interfaces were not modified.

This change should be backward compatible as those types could not be used directly before.

Fixes #7 