### PR TITLE
Remove json marshall properties extra whitespaces and colons

### DIFF
--- a/Bearer.go
+++ b/Bearer.go
@@ -141,15 +141,15 @@ type BearerIpConfig struct {
 // MarshalJSON returns a byte array
 func (bc BearerIpConfig) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
-		"Method":     fmt.Sprint(bc.Method),
-		"Address":    bc.Address,
-		"Prefix":     bc.Prefix,
-		"Dns1: ":     bc.Dns1,
-		"Dns2: ":     bc.Dns2,
-		"Dns3: ":     bc.Dns3,
-		"Gateway: ":  bc.Gateway,
-		"Mtu":        bc.Mtu,
-		"IpFamily: ": fmt.Sprint(bc.IpFamily)})
+		"Method":    fmt.Sprint(bc.Method),
+		"Address":   bc.Address,
+		"Prefix":    bc.Prefix,
+		"Dns1":      bc.Dns1,
+		"Dns2":      bc.Dns2,
+		"Dns3":      bc.Dns3,
+		"Gateway":   bc.Gateway,
+		"Mtu":       bc.Mtu,
+		"IpFamily":  fmt.Sprint(bc.IpFamily)})
 }
 
 func (bc BearerIpConfig) String() string {

--- a/Modem.go
+++ b/Modem.go
@@ -326,8 +326,8 @@ type Port struct {
 // MarshalJSON returns a byte array
 func (po Port) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
-		"PortName":  po.PortName,
-		"PortType ": po.PortType,
+		"PortName": po.PortName,
+		"PortType": po.PortType,
 	})
 }
 
@@ -340,8 +340,8 @@ type Mode struct {
 // MarshalJSON returns a byte array
 func (mo Mode) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
-		"AllowedModes":   mo.AllowedModes,
-		"PreferredMode ": mo.PreferredMode,
+		"AllowedModes":  mo.AllowedModes,
+		"PreferredMode": mo.PreferredMode,
 	})
 }
 

--- a/Modem3gpp.go
+++ b/Modem3gpp.go
@@ -130,10 +130,10 @@ type NetworkScanResult struct {
 // MarshalJSON returns a byte array
 func (nsr NetworkScanResult) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
-		"Networks":      fmt.Sprint(nsr.Networks),
-		"LastScan ":     nsr.LastScan,
-		"ScanDuration ": nsr.ScanDuration,
-		"Recent ":       nsr.Recent,
+		"Networks":     fmt.Sprint(nsr.Networks),
+		"LastScan":     nsr.LastScan,
+		"ScanDuration": nsr.ScanDuration,
+		"Recent":       nsr.Recent,
 	})
 }
 
@@ -159,11 +159,11 @@ type Network3Gpp struct {
 func (n Network3Gpp) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"Status":           fmt.Sprint(n.Status),
-		"OperatorLong ":    n.OperatorLong,
-		"OperatorShort ":   n.OperatorShort,
-		"OperatorCode ":    n.OperatorCode,
-		"Mcc ":             n.Mcc,
-		"Mnc ":             n.Mnc,
+		"OperatorLong":     n.OperatorLong,
+		"OperatorShort":    n.OperatorShort,
+		"OperatorCode":     n.OperatorCode,
+		"Mcc":              n.Mcc,
+		"Mnc":              n.Mnc,
 		"AccessTechnology": fmt.Sprint(n.AccessTechnology),
 	})
 }
@@ -188,8 +188,8 @@ type RawPcoData struct {
 func (r RawPcoData) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"SessionId": r.SessionId,
-		"Complete ": r.Complete,
-		"RawData ":  r.RawData,
+		"Complete":  r.Complete,
+		"RawData":   r.RawData,
 	})
 }
 

--- a/ModemLocation.go
+++ b/ModemLocation.go
@@ -151,10 +151,10 @@ func (cl CurrentLocation) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return json.Marshal(map[string]interface{}{
-		"ThreeGppLacCi ": threeGppLacCiJson,
-		"GpsRaw ":        gpsRawJson,
-		"GpsNmea ":       gpsNmeaJson,
-		"CdmaBs ":        cdmaBsJson,
+		"ThreeGppLacCi": threeGppLacCiJson,
+		"GpsRaw":        gpsRawJson,
+		"GpsNmea":       gpsNmeaJson,
+		"CdmaBs":        cdmaBsJson,
 	})
 }
 

--- a/ModemManager.go
+++ b/ModemManager.go
@@ -95,7 +95,7 @@ type EventProperties struct {
 func (ep EventProperties) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"Action":    ep.Action,
-		"Name ":     ep.Name,
+		"Name":      ep.Name,
 		"Subsystem": ep.Subsystem,
 		"Uid":       ep.Uid,
 	})

--- a/ModemTime.go
+++ b/ModemTime.go
@@ -75,8 +75,8 @@ type ModemTimeZone struct {
 func (mtz ModemTimeZone) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"Offset":       mtz.Offset,
-		"DstOffset ":   mtz.DstOffset,
-		"LeapSeconds ": mtz.LeapSeconds,
+		"DstOffset":    mtz.DstOffset,
+		"LeapSeconds":  mtz.LeapSeconds,
 	})
 }
 

--- a/utils.go
+++ b/utils.go
@@ -78,7 +78,7 @@ func (p Pair) pairToSlice() []interface{} {
 func (p Pair) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"Left":   p.GetLeft(),
-		"Right ": p.GetRight(),
+		"Right":  p.GetRight(),
 	})
 }
 


### PR DESCRIPTION
Some json marshall functions had extra whitespace and colons that break JSON syntax. This commit fixes the issue.