### PR TITLE
Add new modem state failed reasons for unknown capabilities and eSIM profiles

### DIFF
--- a/enums.go
+++ b/enums.go
@@ -100,10 +100,12 @@ type MMModemStateFailedReason uint32
 
 //go:generate stringer -type=MMModemStateFailedReason -trimprefix=MmModemStateFailedReason
 const (
-	MmModemStateFailedReasonNone       MMModemStateFailedReason = 0 // No error.
-	MmModemStateFailedReasonUnknown    MMModemStateFailedReason = 1 // Unknown error.
-	MmModemStateFailedReasonSimMissing MMModemStateFailedReason = 2 // SIM is required but missing.
-	MmModemStateFailedReasonSimError   MMModemStateFailedReason = 3 // SIM is available, but unusable (e.g. permanently locked).
+	MmModemStateFailedReasonNone                MMModemStateFailedReason = 0 // No error.
+	MmModemStateFailedReasonUnknown             MMModemStateFailedReason = 1 // Unknown error.
+	MmModemStateFailedReasonSimMissing          MMModemStateFailedReason = 2 // SIM is required but missing.
+	MmModemStateFailedReasonSimError            MMModemStateFailedReason = 3 // SIM is available, but unusable (e.g. permanently locked).
+	MmModemStateFailedReasonUnknownCapabilities MMModemStateFailedReason = 4 // Unknown modem capabilities.
+	MmModemStateFailedReasonEsimWithoutProfiles MMModemStateFailedReason = 5 // eSIM is not initialized
 
 )
 

--- a/mmmodemstatefailedreason_string.go
+++ b/mmmodemstatefailedreason_string.go
@@ -12,11 +12,13 @@ func _() {
 	_ = x[MmModemStateFailedReasonUnknown-1]
 	_ = x[MmModemStateFailedReasonSimMissing-2]
 	_ = x[MmModemStateFailedReasonSimError-3]
+	_ = x[MmModemStateFailedReasonUnknownCapabilities-4]
+	_ = x[MmModemStateFailedReasonEsimWithoutProfiles-5]
 }
 
-const _MMModemStateFailedReason_name = "NoneUnknownSimMissingSimError"
+const _MMModemStateFailedReason_name = "NoneUnknownSimMissingSimErrorUnknownCapabilitiesEsimWithoutProfiles"
 
-var _MMModemStateFailedReason_index = [...]uint8{0, 4, 11, 21, 29}
+var _MMModemStateFailedReason_index = [...]uint8{0, 4, 11, 21, 29, 48, 67}
 
 func (i MMModemStateFailedReason) String() string {
 	if i >= MMModemStateFailedReason(len(_MMModemStateFailedReason_index)-1) {


### PR DESCRIPTION
This pull request includes changes to the `enums.go` and `mmmodemstatefailedreason_string.go` files to add new modem state failure reasons. These updates ensure that the modem's state can be accurately represented with the new failure reasons added in ModemManager 1.20